### PR TITLE
fix: Fixed configureDependencies return type

### DIFF
--- a/lib/injection/dependencies.dart
+++ b/lib/injection/dependencies.dart
@@ -7,6 +7,6 @@ class DependencyManager {
     injector.registerLazySingleton<AppFlavor>(() => flavor);
     // ignore: unnecessary_lambdas
     injector.registerLazySingleton<AppRouter>(() => AppRouter());
-    configureDependencies();
+    return configureDependencies();
   }
 }

--- a/lib/injection/injector.dart
+++ b/lib/injection/injector.dart
@@ -2,7 +2,7 @@ import 'package:flutter_template/injection/injector.config.dart';
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 
-GetIt injector = GetIt.instance;
+GetIt injector = GetIt.I;
 
 @injectableInit
-void configureDependencies() => injector.init();
+Future<void> configureDependencies() => injector.init();


### PR DESCRIPTION
<!-- Please read the playbook to ensure your PR is good to be reviewed.
https://github.com/monstar-lab-oss/flutter-template/blob/master/playbooks/organization/WorkingWithPullRequests.md
-->

### General

Using `void` is throwing an error in another project right now where we have a global cubit with multiple use cases as dependencies while opening it complains that the cubit is not registered, I found out that—the cubit was not ready for use while using for the first time, so we must add Future<void> as return type, then it works! injectable official documents are proposing `void` but should be `Future<T>`.

- [Jira Ticket](#)

<!-- Provide a brief explanation of the changes introduced by this pull request.
If applicable, describe the issue or feature that this pull request addresses.
Attach screenshots in the "Showcase" section to visually demonstrate the modifications made.
-->

### Checklists

- [ ] Platform specific changes (input, image picking etc) are tested on both of the platforms (Android and iOS)
- [ ] It is tested that the UI changes are rendered correctly on different device sizes (such as long lists or expanded rows) with safe area conditions.
- [ ] Edge cases, such as responses being empty or invalid, missing data, no internet connection etc, are tested and the app works as expected.

### Showcase

- [ ] Either showcase screenshots / videos are attached, or this PR does not require such any showcase.

<!-- Template for attachments:
<img width=265 src=""/>
<video src=""/>
-->
